### PR TITLE
Corrects shebang to be more universal

### DIFF
--- a/phpscanner.py
+++ b/phpscanner.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python2
+#!/usr/bin/env python2
 import yara
 import argparse
 import os


### PR DESCRIPTION
The current shebang doesn't work on OS X, as it says:

> -bash: ./phpscanner/phpscanner.py: /usr/bin/python2: bad interpreter: No such file or directory

This fixes the problem.
